### PR TITLE
Feature: preprocessing with spot duration

### DIFF
--- a/internal-demo/README.md
+++ b/internal-demo/README.md
@@ -89,9 +89,9 @@ private val resultListener: SmartSpectraResultListener = SmartSpectraResultListe
 ### Data Format
 The resultsListener contains the following objects:
 
--  `result.strictPulseRate` - (Double) the strict pulse rate (high confidence average over 30 seconds)
--  `result.strictBreathingRate` - (Double) the strict breathing rate (high confidence average over 30 seconds)
--  `result.pulseValues` - ArrayList<>(time (double), value (double)) Pulse rates 
+- `result.strictPulseRate` - (Double) the strict pulse rate (high confidence average over spot duration)
+- `result.strictBreathingRate` - (Double) the strict breathing rate (high confidence average over spot duration)
+- `result.pulseValues` - ArrayList<>(time (double), value (double)) Pulse rates 
 - `result.pulseConfidence` - ArrayList<>(time (double), value (double)) Pulse rate confidences
 - `result.pulsePleth` - ArrayList<>(time (double), value (double)) Pulse waveform or pleth 
 - `result.breathingValues` - ArrayList<>(time (double), value (double)) Breathing rates

--- a/sdk/jni/arm64-v8a/libmediapipe_jni.so
+++ b/sdk/jni/arm64-v8a/libmediapipe_jni.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:319828bc5cfba08fc25d3a3c893fe9a0b9873fc7225532168f9ecf771858d273
-size 22319824
+oid sha256:1b0cddf524d357b3ad26d5ebbb9589fd5497f43d81037229605307dc0aaf77e9
+size 22319728

--- a/sdk/jni/armeabi-v7a/libmediapipe_jni.so
+++ b/sdk/jni/armeabi-v7a/libmediapipe_jni.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5d9dd18fe39f0acf671f41b899f7a396c23c9f5d3eb52fe7e5667eb72bac812a
+oid sha256:e2b0130eb10e031377caaf63d01b460d8a3bd221c4eaac42387acfb8f4fb740a
 size 7315148

--- a/sdk/src/main/assets/preprocessing_gpu_spot_json.binarypb
+++ b/sdk/src/main/assets/preprocessing_gpu_spot_json.binarypb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7a948b935e94197d83aca2d0207e07d8cd807552e18941a161b86ac9d6d9ec33
-size 1398
+oid sha256:c14b0ab8f8d4ff6fa62445f48f9a8b53a0e3f9ea858502d82df27a66004af0e3
+size 1291

--- a/sdk/src/main/java/com/presagetech/smartspectra/ui/screening/CameraProcessFragment.kt
+++ b/sdk/src/main/java/com/presagetech/smartspectra/ui/screening/CameraProcessFragment.kt
@@ -43,8 +43,11 @@ class CameraProcessFragment : Fragment() {
     private val BINARY_GRAPH_NAME = "preprocessing_gpu_spot_json.binarypb"
     private val INPUT_VIDEO_STREAM_NAME = "input_video"
     private val SELECTED_INPUT_STREAM_NAME = "start_button_pre"
-    private val SPOT_DURATION_SIDE_PACKET_NAME = "spot_duration"
-    private val SPOT_DURATION_DEFAULT_VALUE = 30.0
+
+    private val SPOT_DURATION_SIDE_PACKET_NAME = "spot_duration_s"
+    private val SPOT_DURATION_DEFAULT_VALUE = 40.0
+
+    private val TIME_LEFT_STREAM_NAME = "time_left_s"
 
     private var isRecording: Boolean = false
     private var cameraHelper: MyCameraXPreviewHelper? = null
@@ -109,7 +112,7 @@ class CameraProcessFragment : Fragment() {
             it.videoSurfaceOutput.setFlipY(FLIP_FRAMES_VERTICALLY)
             it.setInputSidePackets(mapOf(SPOT_DURATION_SIDE_PACKET_NAME to it.packetCreator.createFloat64(SPOT_DURATION_DEFAULT_VALUE)))
             it.setOnWillAddFrameListener(::handleOnWillAddFrame)
-            it.addPacketCallback("time_left", ::handleTimeLeftPacket)
+            it.addPacketCallback(TIME_LEFT_STREAM_NAME, ::handleTimeLeftPacket)
             it.addPacketCallback("json_data", ::handleJsonDataPacket)
             it.addPacketCallback("status_code", ::handleStatusCodePacket)
         }

--- a/sdk/src/main/java/com/presagetech/smartspectra/ui/screening/CameraProcessFragment.kt
+++ b/sdk/src/main/java/com/presagetech/smartspectra/ui/screening/CameraProcessFragment.kt
@@ -43,6 +43,8 @@ class CameraProcessFragment : Fragment() {
     private val BINARY_GRAPH_NAME = "preprocessing_gpu_spot_json.binarypb"
     private val INPUT_VIDEO_STREAM_NAME = "input_video"
     private val SELECTED_INPUT_STREAM_NAME = "start_button_pre"
+    private val SPOT_DURATION_SIDE_PACKET_NAME = "spot_duration"
+    private val SPOT_DURATION_DEFAULT_VALUE = 30.0
 
     private var isRecording: Boolean = false
     private var cameraHelper: MyCameraXPreviewHelper? = null
@@ -105,6 +107,7 @@ class CameraProcessFragment : Fragment() {
             "output_video"
         ).also {
             it.videoSurfaceOutput.setFlipY(FLIP_FRAMES_VERTICALLY)
+            it.setInputSidePackets(mapOf(SPOT_DURATION_SIDE_PACKET_NAME to it.packetCreator.createFloat64(SPOT_DURATION_DEFAULT_VALUE)))
             it.setOnWillAddFrameListener(::handleOnWillAddFrame)
             it.addPacketCallback("time_left", ::handleTimeLeftPacket)
             it.addPacketCallback("json_data", ::handleJsonDataPacket)

--- a/sdk/src/main/java/com/presagetech/smartspectra/ui/screening/CameraProcessFragment.kt
+++ b/sdk/src/main/java/com/presagetech/smartspectra/ui/screening/CameraProcessFragment.kt
@@ -45,7 +45,7 @@ class CameraProcessFragment : Fragment() {
     private val SELECTED_INPUT_STREAM_NAME = "start_button_pre"
 
     private val SPOT_DURATION_SIDE_PACKET_NAME = "spot_duration_s"
-    private val SPOT_DURATION_DEFAULT_VALUE = 40.0
+    private val SPOT_DURATION_DEFAULT_VALUE = 30.0
 
     private val TIME_LEFT_STREAM_NAME = "time_left_s"
 


### PR DESCRIPTION
- Use upgraded Preprocessing (graph + ".aar" framework contents) which allows to set the `spot_duration_s` side-packet.

Currently, the SDK sets the spot duration to a constant. However, you can now see how to change that to accept a function parameter from the related SDK function / constructor.
